### PR TITLE
httpclientservice: fix bug crash when log file is big

### DIFF
--- a/httppostclient/cmd.c
+++ b/httppostclient/cmd.c
@@ -4,9 +4,6 @@
 #include "cmd.h"
 #include "config.h"
 
-#define MAX_INPUT_SIZE 1024
-#define MAX_ARGS 128
-
 static void cmd_print_usage(char* program_name) {
     printf("Usage: %s --request <number_of_requests> --input <input message> [--host <host_file>] [--log <log_folder>] [--help]\n", program_name);
     printf("  --request:  Number of requests to process (mandatory)\n");

--- a/httppostclient/httpclient.c
+++ b/httppostclient/httpclient.c
@@ -198,6 +198,7 @@ int httpclient_send_post_msg(httpclient_t* httpclient, char* msg) {
                 continue;
             } else {
                 perror("send");
+                httprequest_deinit(&req);
                 return -1;
             }
         }

--- a/httppostclient/recvworker.c
+++ b/httppostclient/recvworker.c
@@ -88,6 +88,11 @@ static int recvworker_httprespond_timeout_handler(recvworker_t* rw, http_resp_t*
                  "Send Time: %s, Receive Time (Timeout - 10s): %s, Host Info: IP = %s, Port = %d, Sent Message: %s, Message: NULL (Timeout)\n",
                  send_time_str, recv_time_str, rsp->client.host.adress.domain, rsp->client.host.port, sendmsg_content);
 
+        if(log_len >= LOG_MESAGE_MAX_SIZE) {
+            buffer[LOG_MESAGE_MAX_SIZE -1] = '\0';
+            log_len = LOG_MESAGE_MAX_SIZE -1;
+        }
+
         log_write(buffer, log_len);
 
         printf("Host: %s Port %d Respond Code: %d (Timeout)\n", rsp->client.host.adress.domain, rsp->client.host.port, 28);
@@ -114,13 +119,17 @@ static int recvworker_httprespond_event_handler(recvworker_t* rw, http_resp_t* r
 
         const char* sendmsg_content = rsp->sendmsg ? rsp->sendmsg->msg : "No message content";
 
-        int size = snprintf(buffer, sizeof(buffer),
+        int log_len = snprintf(buffer, sizeof(buffer),
                  "Send Time: %s, Receive Time: %s, Host Info: IP = %s, Port = %d, Sent Message: %s, Received Message: %.*s",
                  send_time_str, recv_time_str, rsp->client.host.adress.domain, rsp->client.host.port,
                  sendmsg_content, len, msg);
 
-        log_write(buffer, size);
+        if(log_len >= LOG_MESAGE_MAX_SIZE) {
+            buffer[LOG_MESAGE_MAX_SIZE -1] = '\0';
+            log_len = LOG_MESAGE_MAX_SIZE -1;
+        }
 
+        log_write(buffer, log_len);
         int error = recvworker_analyze_httprespond(msg, len);
 
         printf("Host: %s Port %d Respond Code: %d (Success)\n", rsp->client.host.adress.domain, rsp->client.host.port, error);

--- a/httppostclient/sendworker.c
+++ b/httppostclient/sendworker.c
@@ -82,8 +82,6 @@ int sendworker_init(sendworker_t* sw) {
         }
     }
 
-    printf("sendworker_init: Initialization complete\n");
-
     return 0;
 }
 

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -45,6 +45,7 @@ void buffer_write_with_retry(buffer_t* cb, const char* data, size_t len, int ret
 
         cb->head = (cb->head + 1) % cb->capacity;
         cb->count--;
+
     }
 
     cb->entries[cb->tail].data = (char*)malloc(len);


### PR DESCRIPTION
- add end character '\0' to log buffer