### PR TITLE
httpclientservice: fix issue crash with invalid input file

### DIFF
--- a/httppostclient/config.c
+++ b/httppostclient/config.c
@@ -54,6 +54,23 @@ int config_set_msg_file(const char* msg_file) {
         return -1;
     }
 
+    const char *dot = strrchr(msg_file, '.');
+    if (!dot || strcmp(dot, ".txt") != 0) {
+        fprintf(stderr, "File is not a .txt file\n");
+        return -1;
+    }
+
+    struct stat st;
+    if (stat(msg_file, &st) != 0) {
+        perror("Failed to get file size");
+        return -1;
+    }
+
+    if (st.st_size > MAX_INPUT_FILE_SIZE) {
+        fprintf(stderr, "File size exceeds 2KB\n");
+        return -1;
+    }
+
     if (config.msg_file) {
         free(config.msg_file);
     }

--- a/httppostclient/config.h
+++ b/httppostclient/config.h
@@ -1,6 +1,8 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+#define MAX_INPUT_FILE_SIZE 2048
+
 typedef struct config_item_t
 {
     char* msg_file;


### PR DESCRIPTION
- check input file with extension .txt
- check input file size not exceed 2Kb